### PR TITLE
Add documentation for mini libraries and create pages directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY: bump
+
+bump:
+	@if [ -z "$(mod)" ]; then \
+		echo "Error: mod is required. Usage: make bump mod=<module_name> ver=<version>"; \
+		exit 1; \
+	fi
+	@if [ -z "$(ver)" ]; then \
+		echo "Error: ver is required. Usage: make bump mod=<module_name> ver=<version>"; \
+		exit 1; \
+	fi
+	@if [ ! -d "$(mod)" ]; then \
+		echo "Error: module '$(mod)' does not exist"; \
+		exit 1; \
+	fi
+	git tag $(mod)/$(ver)
+	@echo "Successfully created tag $(mod)/$(ver)"
+	@echo "Don't forget to push: git push origin $(mod)/$(ver)"

--- a/etr/etr.go
+++ b/etr/etr.go
@@ -1,3 +1,4 @@
+// Package etr (Echo Templ Renderer) provides helper functions for rendering templ components with Echo.
 package etr
 
 import (
@@ -12,11 +13,14 @@ import (
 
 type (
 	xcontextkey string
+	// QS is a type alias for a query string map.
 	QS          = map[string]string
 )
 
 var xc xcontextkey = "xcontext"
 
+// Render renders a templ component with the given status code and data.
+// It injects context values like request, url, reverse function, and csrf token.
 func Render(c *echo.Context, status int, tpl templ.Component, data any) error {
 	c.Response().WriteHeader(status)
 
@@ -41,6 +45,7 @@ func Render(c *echo.Context, status int, tpl templ.Component, data any) error {
 	return nil
 }
 
+// Get retrieves a value from the context injected by Render.
 func Get[T any](ctx context.Context, key string) T {
 	var cx map[string]any
 	if v := ctx.Value(xc); v != nil {
@@ -53,6 +58,7 @@ func Get[T any](ctx context.Context, key string) T {
 	return r
 }
 
+// Reverse generates a URL for a named route using the reverse function in the context.
 func Reverse(cx context.Context, name string, values ...any) string {
 	reverse := Get[func(string, ...any) (string, error)](cx, "reverse")
 	path, err := reverse(name, values...)
@@ -62,6 +68,7 @@ func Reverse(cx context.Context, name string, values ...any) string {
 	return path
 }
 
+// ReverseX generates a URL for a named route using the Echo context directly.
 func ReverseX(c *echo.Context, name string, values ...any) string {
 	path, err := c.Echo().Router().Routes().Reverse(name, values...)
 	if err != nil {
@@ -70,6 +77,7 @@ func ReverseX(c *echo.Context, name string, values ...any) string {
 	return path
 }
 
+// WithQS appends query string parameters to a URL.
 func WithQS(url_ string, qs map[string]string) string {
 	u, err := url.Parse(url_)
 	if err != nil {
@@ -84,6 +92,7 @@ func WithQS(url_ string, qs map[string]string) string {
 	return u.String()
 }
 
+// GetCSRF retrieves the CSRF token from the context.
 func GetCSRF(ctx context.Context) string {
 	return Get[string](ctx, "csrf")
 }

--- a/pages/index.md
+++ b/pages/index.md
@@ -81,7 +81,7 @@ func Handler(c echo.Context) error {
 
 A lightweight library for populating struct fields from environment variables.
 
-See [xenv/README.md](xenv/README.md) for full documentation.
+See [xenv/README.md](../xenv/README.md) for full documentation.
 
 ### xlog
 

--- a/pbc/pbclient.go
+++ b/pbc/pbclient.go
@@ -1,3 +1,4 @@
+// Package pbc (PocketBase Client) provides a client for interacting with the PocketBase API.
 package pbc
 
 import (
@@ -25,12 +26,14 @@ func getEndpoint(endpoint string, params ...any) string {
 	return fmt.Sprintf(endpoint, params...)
 }
 
+// Client is the PocketBase client.
 type Client struct {
 	BaseURL string
 	Token   string
 	Client  *clink.Client
 }
 
+// New creates a new PocketBase client.
 func New(baseURL string) Client {
 	c := clink.NewClient()
 	c.Headers["Content-Type"] = "application/json"
@@ -77,6 +80,7 @@ func (c Client) buildUrl(path string, query *Query) string {
 	return u.String()
 }
 
+// Request sends a request to the PocketBase API.
 func (c *Client) Request(method, url string, opts ...QueryOption) (*http.Response, error) {
 	query := NewQuery(opts...)
 	url = c.buildUrl(url, query)
@@ -104,11 +108,13 @@ func (c *Client) Request(method, url string, opts ...QueryOption) (*http.Respons
 	return resp, nil
 }
 
+// Health checks the health of the PocketBase server.
 func (c *Client) Health() (HealthResponse, error) {
 	resp, err := c.Request(http.MethodGet, EndpointHealth)
 	return ResponseTo[HealthResponse](resp), err
 }
 
+// Auth performs authentication.
 func (c *Client) Auth(endpoint, username, password string) (*http.Response, error) {
 	payload := RequestAuth{
 		Identity: username,
@@ -117,39 +123,47 @@ func (c *Client) Auth(endpoint, username, password string) (*http.Response, erro
 	return c.Request(http.MethodPost, endpoint, WithData(payload))
 }
 
+// AdminAuth authenticates as an admin.
 func (c *Client) AdminAuth(username, password string) (*http.Response, error) {
 	return c.Auth(EndpointAuthAdmin, username, password)
 }
 
+// UserAuth authenticates as a user.
 func (c *Client) UserAuth(username, password string) (*http.Response, error) {
 	return c.Auth(EndpointAuthUser, username, password)
 }
 
+// RecordCreate creates a new record in the specified collection.
 func (c *Client) RecordCreate(name string, opts ...QueryOption) (*http.Response, error) {
 	opts = append(opts, WithParams(name))
 	return c.Request(http.MethodPost, EndpointRecords, opts...)
 }
 
+// RecordGet retrieves a record by ID from the specified collection.
 func (c *Client) RecordGet(name string, id string, opts ...QueryOption) (*http.Response, error) {
 	opts = append(opts, WithParams(name, id))
 	return c.Request(http.MethodGet, EndpointRecordID, opts...)
 }
 
+// RecordList lists records from the specified collection.
 func (c *Client) RecordList(name string, opts ...QueryOption) (*http.Response, error) {
 	opts = append(opts, WithParams(name))
 	return c.Request(http.MethodGet, EndpointRecords, opts...)
 }
 
+// RecordUpdate updates a record by ID in the specified collection.
 func (c *Client) RecordUpdate(name string, id string, opts ...QueryOption) (*http.Response, error) {
 	opts = append(opts, WithParams(name, id))
 	return c.Request(http.MethodPatch, EndpointRecordID, opts...)
 }
 
+// RecordDelete deletes a record by ID from the specified collection.
 func (c *Client) RecordDelete(name string, id string, opts ...QueryOption) (*http.Response, error) {
 	opts = append(opts, WithParams(name, id))
 	return c.Request(http.MethodDelete, EndpointRecordID, opts...)
 }
 
+// ResponseTo unmarshals the response body into a given type T.
 func ResponseTo[T any](resp *http.Response) T {
 	var t T
 	if err := clink.ResponseToJson(resp, &t); err != nil {

--- a/spbautherror/spbautherror.go
+++ b/spbautherror/spbautherror.go
@@ -1,3 +1,4 @@
+// Package spbautherror provides utilities for parsing Supabase authentication errors.
 package spbautherror
 
 import (
@@ -13,7 +14,7 @@ type Response struct {
 	Msg       string `json:"msg"`
 }
 
-// UnmarshalAuthError parses the specific error string format and extracts the Response.
+// Unmarshal parses the specific error string format and extracts the Response.
 func Unmarshal(errorString string) (*Response, error) {
 	// Find the start of the JSON part
 	jsonStart := strings.Index(errorString, "{")

--- a/toast/toast.go
+++ b/toast/toast.go
@@ -1,3 +1,4 @@
+// Package toast provides helper functions for sending toast notifications in Echo applications.
 package toast
 
 import (
@@ -27,16 +28,21 @@ var (
 	ToastNull = Toast{}
 )
 
+// Toast represents a toast notification message.
 type Toast struct {
 	Kind    string `json:"type"`
 	Title   string `json:"title"`
 	Message string `json:"message"`
 }
 
+// ToastEvent wraps a Toast for HTMX events.
 type ToastEvent struct {
 	Event Toast `json:"toast"`
 }
 
+// Notify sends a toast notification.
+// If the request is an HTMX request, it sets the HX-Trigger header.
+// Otherwise, it sets a cookie.
 func Notify(c *echo.Context, kind string, title string, msg string) {
 	t := ToastEvent{
 		Event: Toast{
@@ -58,34 +64,42 @@ func Notify(c *echo.Context, kind string, title string, msg string) {
 	c.SetCookie(cookie)
 }
 
+// Success creates a success toast.
 func Success(msg string) Toast {
 	return Toast{KindSuccess, TitleSuccess, msg}
 }
 
+// Error creates an error toast.
 func Error(msg string) Toast {
 	return Toast{KindError, TitleError, msg}
 }
 
+// Warning creates a warning toast.
 func Warning(msg string) Toast {
 	return Toast{KindWarning, TitleWarning, msg}
 }
 
+// Info creates an info toast.
 func Info(msg string) Toast {
 	return Toast{KindInfo, TitleInfo, msg}
 }
 
+// NotifySuccess sends a success notification.
 func NotifySuccess(c *echo.Context, msg string) {
 	Notify(c, KindSuccess, TitleSuccess, msg)
 }
 
+// NotifyError sends an error notification.
 func NotifyError(c *echo.Context, msg string) {
 	Notify(c, KindError, TitleError, msg)
 }
 
+// NotifyWarning sends a warning notification.
 func NotifyWarning(c *echo.Context, msg string) {
 	Notify(c, KindWarning, TitleWarning, msg)
 }
 
+// NotifyInfo sends an info notification.
 func NotifyInfo(c *echo.Context, msg string) {
 	Notify(c, KindInfo, TitleInfo, msg)
 }
@@ -99,6 +113,7 @@ func marshallFrom[T any](t T) string {
 	return string(d)
 }
 
+// UnmarshallToast extracts a toast from the HTMX header if present.
 func UnmarshallToast(c *echo.Context) Toast {
 	var t ToastEvent
 	if value := c.Request().Header.Get(HeaderKey); value != "" {

--- a/xenv/xenv.go
+++ b/xenv/xenv.go
@@ -1,3 +1,4 @@
+// Package xenv provides functionality to load environment variables into struct fields.
 package xenv
 
 import (
@@ -14,11 +15,12 @@ type Options struct {
 	Prefix string
 }
 
+// Load populates a struct using environment variables.
 func Load(container any) error {
 	return LoadWithOptions(container, Options{})
 }
 
-// LoadOptions populates a struct using environment variables with an optional prefix.
+// LoadWithOptions populates a struct using environment variables with an optional prefix.
 func LoadWithOptions(container any, opts Options) error {
 	val := reflect.ValueOf(container)
 	if val.Kind() == reflect.Ptr {

--- a/xlog/xlog.go
+++ b/xlog/xlog.go
@@ -1,3 +1,4 @@
+// Package xlog provides a structured logger based on log/slog.
 package xlog
 
 import (
@@ -43,18 +44,22 @@ func init() {
 	logger = slog.New(handler)
 }
 
+// Info logs a message at Info level.
 func Info(msg string, args ...any) {
 	logger.Info(msg, args...)
 }
 
+// Debug logs a message at Debug level.
 func Debug(msg string, args ...any) {
 	logger.Debug(msg, args...)
 }
 
+// Error logs a message at Error level.
 func Error(msg string, args ...any) {
 	logger.Error(msg, args...)
 }
 
+// Warn logs a message at Warn level.
 func Warn(msg string, args ...any) {
 	logger.Warn(msg, args...)
 }

--- a/xsession/xsession.go
+++ b/xsession/xsession.go
@@ -1,3 +1,4 @@
+// Package xsession provides session management middleware and helpers for Echo, backed by alexedwards/scs.
 package xsession
 
 import (
@@ -12,8 +13,10 @@ import (
 	"github.com/labstack/echo/v5/middleware"
 )
 
+// SessionName is the key used for storing user session data.
 const SessionName = "xtoken"
 
+// XUser represents a user in the session.
 type XUser struct {
 	ID    string            `json:"id"`
 	Token string            `json:"token"`
@@ -21,6 +24,7 @@ type XUser struct {
 	Data  map[string]string `json:"data"`
 }
 
+// NewXUser creates a new XUser.
 func NewXUser(id, token, email string, data map[string]string) XUser {
 	if len(data) == 0 {
 		data = make(map[string]string)
@@ -31,27 +35,33 @@ func NewXUser(id, token, email string, data map[string]string) XUser {
 	}
 }
 
+// SetData sets a key-value pair in the user's data.
 func (x *XUser) SetData(key, value string) {
 	x.Data[key] = value
 }
 
+// GetData retrieves a value from the user's data by key.
 func (x *XUser) GetData(key string) string {
 	return x.Data[key]
 }
 
+// DeleteData removes a key from the user's data.
 func (x *XUser) DeleteData(key string) {
 	delete(x.Data, key)
 }
 
+// SessionConfig defines the configuration for the session middleware.
 type SessionConfig struct {
 	Skipper        middleware.Skipper
 	SessionManager *scs.SessionManager
 }
 
+// DefaultSessionConfig is the default configuration for the session middleware.
 var (
 	DefaultSessionConfig = SessionConfig{
 		Skipper: middleware.DefaultSkipper,
 	}
+	// SessionManager is the global session manager instance.
 	SessionManager *scs.SessionManager
 )
 
@@ -60,6 +70,7 @@ func init() {
 	SessionManager.Lifetime = 1 * time.Hour
 }
 
+// LoadAndSave is a middleware that loads and saves session data.
 func LoadAndSave(sessionManager *scs.SessionManager) echo.MiddlewareFunc {
 	c := DefaultSessionConfig
 	c.SessionManager = sessionManager
@@ -67,6 +78,7 @@ func LoadAndSave(sessionManager *scs.SessionManager) echo.MiddlewareFunc {
 	return LoadAndSaveWithConfig(c)
 }
 
+// LoadAndSaveWithConfig is a middleware that loads and saves session data with a custom configuration.
 func LoadAndSaveWithConfig(config SessionConfig) echo.MiddlewareFunc {
 
 	if config.Skipper == nil {
@@ -146,6 +158,8 @@ func addHeaderIfMissing(w http.ResponseWriter, key, value string) {
 	w.Header().Add(key, value)
 }
 
+// LoginRequired is a middleware that requires the user to be logged in.
+// If the user is not logged in, it redirects to the specified path.
 func LoginRequired(redirectPath string) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c *echo.Context) error {
@@ -158,6 +172,8 @@ func LoginRequired(redirectPath string) echo.MiddlewareFunc {
 	}
 }
 
+// LoginRequiredFunc is a middleware that requires the user to be logged in.
+// If the user is not logged in, it executes the provided function.
 func LoginRequiredFunc(fn echo.HandlerFunc) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c *echo.Context) error {
@@ -170,6 +186,7 @@ func LoginRequiredFunc(fn echo.HandlerFunc) echo.MiddlewareFunc {
 	}
 }
 
+// Get retrieves a value from the session context.
 func Get[T any](c context.Context, name string) T {
 	var r T
 	if v, ok := SessionManager.Get(c, name).(T); ok {
@@ -178,19 +195,23 @@ func Get[T any](c context.Context, name string) T {
 	return r
 }
 
+// Set sets a value in the session context.
 func Set(c context.Context, name string, value any) {
 	SessionManager.Put(c, name, value)
 }
 
+// Delete removes a value from the session context.
 func Delete(c context.Context, name string) {
 	SessionManager.Remove(c, name)
 }
 
+// SetUser stores the user in the session.
 func SetUser(c context.Context, u XUser) {
 	b, _ := json.Marshal(u)
 	Set(c, SessionName, b)
 }
 
+// GetUser retrieves the user from the session.
 func GetUser(c context.Context) XUser {
 	b := Get[[]byte](c, SessionName)
 	var u XUser
@@ -198,10 +219,12 @@ func GetUser(c context.Context) XUser {
 	return u
 }
 
+// DeleteUser removes the user from the session.
 func DeleteUser(c context.Context) {
 	Delete(c, SessionName)
 }
 
+// IsAuthenticated checks if the user is authenticated (i.e., has an ID).
 func IsAuthenticated(c context.Context) bool {
 	return GetUser(c).ID != ""
 }


### PR DESCRIPTION
Updated the repository documentation by providing detailed descriptions and usage examples for all mini-libraries in the root README.md. Additionally, created a `pages/` directory with an `index.md` file to serve as the entry point for GitHub Pages, mirroring the documentation.

---
*PR created automatically by Jules for task [11895435721948106680](https://jules.google.com/task/11895435721948106680) started by @josuebrunel*